### PR TITLE
[Update]: accept App ID in OTP function, removing fixed app ID

### DIFF
--- a/BeemAfrica/OTP.py
+++ b/BeemAfrica/OTP.py
@@ -13,9 +13,12 @@ class OTP(object):
         pass
 
     @secured
-    def send_otp(self, recipient=None, app_id=126) -> dict:
+    def send_otp(self, recipient=None, app_id=None) -> dict:
         if not recipient:
             raise ValueError('recipient number should not be empty')
+        
+        if not app_id:
+            raise ValueError('App ID should not be empty, this is your Beem App ID')
 
         if not isinstance(app_id, int):
             raise TypeError(


### PR DESCRIPTION
In the latest version OTP function sets app id to a fixed app   id which is 126, this returns an error because every client have a unique app id, so clients need to pass their app id in OTP function